### PR TITLE
fix eating bug

### DIFF
--- a/src/LDX/iProtector/Main.php
+++ b/src/LDX/iProtector/Main.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace LDX\iProtector;
 
+use pocketmine\block\Air;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\entity\Entity;
@@ -398,8 +399,10 @@ class Main extends PluginBase implements Listener{
 	public function onBlockTouch(PlayerInteractEvent $event) : void{
 		$block = $event->getBlock();
 		$player = $event->getPlayer();
-		if(!$this->canTouch($player, $block)){
-			$event->setCancelled();
+		if(!($block instanceof Air)){
+			if(!$this->canTouch($player, $block)){
+				$event->setCancelled();
+			}
 		}
 	}
 

--- a/src/LDX/iProtector/Main.php
+++ b/src/LDX/iProtector/Main.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace LDX\iProtector;
 
-use pocketmine\block\Air;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\entity\Entity;
@@ -399,7 +398,7 @@ class Main extends PluginBase implements Listener{
 	public function onBlockTouch(PlayerInteractEvent $event) : void{
 		$block = $event->getBlock();
 		$player = $event->getPlayer();
-		if(!($block instanceof Air)){
+		if($event->getAction() !== PlayerInteractEvent::RIGHT_CLICK_AIR){
 			if(!$this->canTouch($player, $block)){
 				$event->setCancelled();
 			}


### PR DESCRIPTION
This PR, fixes a bug where eating in a world where there was an area the event was canceled because the coordinates of the block of air were found to be x: 0, y: 0, z: 0